### PR TITLE
feat: blog is main. use content folders as subdirectories

### DIFF
--- a/content/mappings/author.json
+++ b/content/mappings/author.json
@@ -170,5 +170,9 @@
     "id": "philweiss@clausehound.com",
     "first": "Phil",
     "last": "Weiss"
+  },
+  { "id": "greg@clausehound.com",
+    "first": "Greg",
+    "last": "O'Grady"
   }
 ]

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,6 +20,13 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
+        path: `${__dirname}/content/tech`,
+        name: `tech`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
         path: `${__dirname}/content/assets`,
         name: `assets`,
       },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,6 +11,7 @@ async function getPosts({ graphql }) {
         ) {
           edges {
             node {
+              fileAbsolutePath
               fields {
                 slug
               }
@@ -69,48 +70,73 @@ const blogList = path.resolve(`./src/templates/blog-list.ts`);
 
 const postsPerPage = 0xff;
 
-const listPath = i => {
+const listPath = (i, subdir) => {
+  const base = subdir === 'blog' ? '' : `/${subdir}`
   if (i < 0) return null;
-  if (i === 0) return "/";
-  return `/page/${i + 1}`;
+  if (i === 0) return `${base}/`;
+  return `${base}/page/${i + 1}`;
 };
 
-exports.createPages = async ({ graphql, actions }) =>
+const getSubdir = path => path.split("/").slice(-3)[0];
+
+exports.createPages = async ({ graphql, actions }) => {
   Promise.all([
-    getPosts({ graphql }).then(posts => {
-      const numPages = Math.ceil(posts.length / postsPerPage);
+    getPosts({ graphql }).then(allPosts => {
+      // organize by subdir
+      const subdirs = allPosts.reduce(
+        (a, post) =>
+          a.set(
+            getSubdir(post.node.fileAbsolutePath),
+            (a.get(getSubdir(post.node.fileAbsolutePath)) || []).concat(post),
+          ),
+        new Map(),
+      );
 
-      return [
-        // Make all the full blog entry pages
-        posts.map((post, index) => {
-          const previous =
-            index === posts.length - 1 ? null : posts[index + 1].node;
-          const next = index === 0 ? null : posts[index - 1].node;
+      // Make all the full blog entry pages
+      return Array.from(subdirs)
+        .map(x => {
+          const [subdir, posts] = x;
+          const numPages = Math.ceil(posts.length / postsPerPage);
 
-          return {
-            path: post.node.fields.slug,
-            component: blogPost,
-            context: {
-              slug: post.node.fields.slug,
-              previous,
-              next,
-            },
-          };
-        }),
-        // Build all the paginated main pages
-        Array.from({ length: numPages }, (_, i) => ({
-          path: listPath(i),
-          component: blogList,
-          context: {
-            limit: postsPerPage,
-            skip: i * postsPerPage,
-            numPages,
-            currentPage: i + 1,
-            previousPath: listPath(i - 1),
-            nextPath: listPath(i + 1),
-          },
-        })),
-      ];
+          return [
+            // Make all the full blog entry pages for this subdir
+            posts.map((post, index) => {
+              const previous =
+                index === posts.length - 1 ? null : posts[index + 1].node;
+              const next = index === 0 ? null : posts[index - 1].node;
+              return {
+                path: post.node.fields.slug,
+                component: blogPost,
+                context: {
+                  slug: post.node.fields.slug,
+                  previous,
+                  next,
+                },
+              };
+            }),
+            // Build all the paginated main pages for this subdir
+            Array.from({ length: numPages }, (_, i) => ({
+              path: listPath(i, subdir),
+              component: blogList,
+              context: {
+                limit: postsPerPage,
+                skip: i * postsPerPage,
+                subdir,
+                numPages,
+                currentPage: i + 1,
+                previousPath: listPath(i - 1, subdir),
+                nextPath: listPath(i + 1, subdir),
+              },
+            })),
+          ];
+        })
+        .reduce(
+          ([aPosts, aLists], [posts, lists]) => [
+            aPosts.concat(posts),
+            aLists.concat(lists),
+          ],
+          [[], []],
+        );
     }),
     getAuthors({ graphql }).then(authors =>
       authors.map(({ node }) => ({
@@ -123,20 +149,27 @@ exports.createPages = async ({ graphql, actions }) =>
     ),
   ]).then(([[posts, lists], authors]) => {
     // TODO: Check here if we have a slug collision and rename appropriately
-    [...posts, ...lists, ...authors].forEach(page => {
-      actions.createPage(page);
-    });
+    [...posts, ...lists, ...authors].forEach(page => actions.createPage(page));
   });
+};
 
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions;
 
   if (node.internal.type === `MarkdownRemark`) {
+    const subdir = getNode(node.parent).sourceInstanceName;
     const value = createFilePath({ node, getNode });
+    const slug = subdir === "blog" ? value : `/${subdir}${value}`;
+
     createNodeField({
       name: `slug`,
       node,
-      value,
+      value: slug,
+    });
+    createNodeField({
+      name: `subdir`,
+      node,
+      value: subdir,
     });
   }
 };

--- a/src/templates/blog-list.ts
+++ b/src/templates/blog-list.ts
@@ -85,8 +85,9 @@ const BlogList: FC<Props> = ({ data, location, pageContext }) => {
 };
 
 export default BlogList;
+
 export const pageQuery = graphql`
-  query($skip: Int, $limit: Int) {
+  query($skip: Int, $limit: Int, $subdir: String) {
     site {
       siteMetadata {
         title
@@ -94,6 +95,7 @@ export const pageQuery = graphql`
     }
     allMarkdownRemark(
       sort: { fields: [frontmatter___date], order: DESC }
+      filter: { fields: { subdir: { eq: $subdir } } }
       limit: $limit
       skip: $skip
     ) {


### PR DESCRIPTION
Automatically pick up subdirectories (such as `/tech`) and add the pages / create a paginated index list page as well. 
The index list pages reuse `blog-list` with a filter on the added `subdir` property that's added to the individual pages