### PR TITLE
feat: add a dark-mode linked to media query

### DIFF
--- a/src/components/article-preview.ts
+++ b/src/components/article-preview.ts
@@ -35,7 +35,6 @@ const ArticlePreview: FC<Props> = ({ date, description, slug, tags, title }) =>
             style: {
               boxShadow: `none`,
               textDecoration: "none",
-              color: "var(--text)",
             },
             to: slug,
           },

--- a/src/components/layout.ts
+++ b/src/components/layout.ts
@@ -6,6 +6,7 @@ import {
   makeStyles,
 } from "@material-ui/core/styles";
 import { amber, lightBlue, grey } from "@material-ui/core/colors";
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 import { rhythm, scale } from "../utils/typography";
 
@@ -13,7 +14,7 @@ import Header from "./header";
 
 declare var __PATH_PREFIX__: string;
 
-const palette = {
+const paletteLight = {
   primary: {
     light: amber[500],
     main: amber[700],
@@ -21,15 +22,38 @@ const palette = {
     contrastText: "#ffffff",
   },
   secondary: {
-    light: lightBlue[100],
-    main: lightBlue[300],
-    dark: lightBlue[500],
+    light: lightBlue[500],
+    main: lightBlue[700],
+    dark: lightBlue[900],
     contrastText: "#ffffff",
   },
 } as const;
 
-const theme = createMuiTheme({
-  palette,
+const paletteDark = {
+  type: "dark",
+  background: {
+    default: grey[900],
+    paper: grey[700],
+  },
+  text: {
+    primary: grey[100],
+  },
+  primary: {
+    light: amber[500],
+    main: amber[700],
+    dark: amber[900],
+    contrastText: "#dddddd",
+  },
+  secondary: {
+    light: lightBlue[100],
+    main: lightBlue[300],
+    dark: lightBlue[500],
+    contrastText: "#dddddd",
+  },
+} as const;
+
+const themeLight = createMuiTheme({
+  palette: paletteLight,
   typography: {
     fontFamily: ["Montserrat", "sans-serif"].join(","),
     h1: {
@@ -42,38 +66,79 @@ const theme = createMuiTheme({
   },
 });
 
-const colorVars = {
-  "--primary": palette.primary.main,
-  "--primary-light": palette.primary.light,
-  "--primary-dark": palette.primary.dark,
-  "--secondary": palette.secondary.main,
-  "--secondary-light": palette.secondary.light,
-  "--secondary-dark": palette.secondary.dark,
-  "--text": theme.palette.text.primary,
+const themeDark = createMuiTheme({
+  palette: paletteDark,
+  typography: {
+    fontFamily: ["Montserrat", "sans-serif"].join(","),
+    h1: {
+      fontSize: "2.2rem",
+      fontWeight: 700,
+    },
+    h5: {
+      fontWeight: 700,
+    },
+  },
+});
+
+const colorVarsLight = {
+  "--primary": paletteLight.primary.main,
+  "--primary-light": paletteLight.primary.light,
+  "--primary-dark": paletteLight.primary.dark,
+  "--secondary": paletteLight.secondary.main,
+  "--secondary-light": paletteLight.secondary.light,
+  "--secondary-dark": paletteLight.secondary.dark,
+} as const;
+
+const colorVarsDark = {
+  "--primary": paletteDark.primary.main,
+  "--primary-light": paletteDark.primary.light,
+  "--primary-dark": paletteDark.primary.dark,
+  "--secondary": paletteDark.secondary.main,
+  "--secondary-light": paletteDark.secondary.light,
+  "--secondary-dark": paletteDark.secondary.dark,
+  "--text": paletteDark.text.primary,
 } as const;
 
 // All the keys for these, so we can make sure we use the right vars
-export type ColorVars = keyof typeof colorVars;
+export type ColorVars = keyof typeof colorVarsLight;
+const linkStyle = {
+  "& a": {
+    color: "var(--secondary)",
+    "&:visited": {
+      color: "var(--secondary-light)",
+    },
+    "&:hover": {
+      color: "var(--secondary-dark)",
+    },
+  },
+} as const;
 
 // Set this same theme as style vars
-const useStyles = makeStyles({
+const useStylesLight = makeStyles(theme => ({
   root: {
-    ...colorVars,
-    "& a": {
-      color: "var(--secondary)",
-      "&:visited": {
-        color: "var(--secondary-light)",
-      },
-      "&:hover": {
-        color: "var(--secondary-dark)",
-      },
-    },
+    ...colorVarsLight,
+    ...linkStyle,
   },
   main: {
     margin: "0 auto",
     padding: "1rem 1rem",
   },
-});
+}));
+
+const useStylesDark = makeStyles(theme => ({
+  root: {
+    ...colorVarsDark,
+    ...linkStyle,
+    // TODO: find why this isn't being set in the theme
+    background: grey[900],
+    minHeight: "100vh",
+  },
+  main: {
+    margin: "0 auto",
+    padding: "1rem 1rem",
+    color: "var(--text)",
+  },
+}));
 
 interface Props {
   location: Location;
@@ -82,7 +147,8 @@ interface Props {
 
 const Layout: FC<Props> = ({ location, title, children }) => {
   const rootPath = `${__PATH_PREFIX__}/`;
-  const classes = useStyles();
+  const darkMode = useMediaQuery("(prefers-color-scheme: dark)");
+  const classes = darkMode ? useStylesDark() : useStylesLight();
 
   return h(
     "div",
@@ -90,7 +156,7 @@ const Layout: FC<Props> = ({ location, title, children }) => {
     h(
       MuiThemeProvider,
       {
-        theme,
+        theme: darkMode ? themeDark : themeLight,
       },
       h(Header),
       h(
@@ -105,7 +171,7 @@ const Layout: FC<Props> = ({ location, title, children }) => {
       ),
       h(
         "footer",
-        { style: { textAlign: "right", marginRight: "1rem" } },
+        { style: { color: "var(--text)", textAlign: "right", marginRight: "1rem" } },
         "\xA9 ",
         new Date().getFullYear(),
         ", Built with",

--- a/src/components/layout.ts
+++ b/src/components/layout.ts
@@ -6,7 +6,7 @@ import {
   makeStyles,
 } from "@material-ui/core/styles";
 import { amber, lightBlue, grey } from "@material-ui/core/colors";
-import useMediaQuery from '@material-ui/core/useMediaQuery';
+import useMediaQuery from "@material-ui/core/useMediaQuery";
 
 import { rhythm, scale } from "../utils/typography";
 
@@ -52,32 +52,25 @@ const paletteDark = {
   },
 } as const;
 
+const typography = {
+  fontFamily: ["Montserrat", "sans-serif"].join(","),
+  h1: {
+    fontSize: "2.2rem",
+    fontWeight: 700,
+  },
+  h5: {
+    fontWeight: 700,
+  },
+} as const;
+
 const themeLight = createMuiTheme({
   palette: paletteLight,
-  typography: {
-    fontFamily: ["Montserrat", "sans-serif"].join(","),
-    h1: {
-      fontSize: "2.2rem",
-      fontWeight: 700,
-    },
-    h5: {
-      fontWeight: 700,
-    },
-  },
+  typography,
 });
 
 const themeDark = createMuiTheme({
   palette: paletteDark,
-  typography: {
-    fontFamily: ["Montserrat", "sans-serif"].join(","),
-    h1: {
-      fontSize: "2.2rem",
-      fontWeight: 700,
-    },
-    h5: {
-      fontWeight: 700,
-    },
-  },
+  typography,
 });
 
 const colorVarsLight = {
@@ -171,7 +164,13 @@ const Layout: FC<Props> = ({ location, title, children }) => {
       ),
       h(
         "footer",
-        { style: { color: "var(--text)", textAlign: "right", marginRight: "1rem" } },
+        {
+          style: {
+            color: "var(--text)",
+            textAlign: "right",
+            marginRight: "1rem",
+          },
+        },
         "\xA9 ",
         new Date().getFullYear(),
         ", Built with",

--- a/src/templates/blog-list.ts
+++ b/src/templates/blog-list.ts
@@ -12,7 +12,7 @@ interface Props {
   pageContext: any;
 }
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles({
   prevNext: {
     display: `flex`,
     flexWrap: `wrap`,
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
       marginBottom: "0.2rem",
     }
   },
-}));
+});
 
 const BlogList: FC<Props> = ({ data, location, pageContext }) => {
   const siteTitle = data.site.siteMetadata.title;


### PR DESCRIPTION
Adds a dark theme, linked to the media query of your browser's preferences.

We'll probably want a button later:
![image](https://user-images.githubusercontent.com/586985/78150068-c4488680-7404-11ea-9a42-5aa0c100512d.png)
